### PR TITLE
feat: 계정 잠금 기능 추가, 로그아웃 추가, Swagger UI 설명 추가

### DIFF
--- a/src/main/java/com/min/i/memory_BE/domain/user/controller/LoginController.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/controller/LoginController.java
@@ -2,14 +2,23 @@ package com.min.i.memory_BE.domain.user.controller;
 
 import com.min.i.memory_BE.domain.user.dto.JwtAuthenticationResponse;
 import com.min.i.memory_BE.domain.user.dto.UserLoginDto;
+import com.min.i.memory_BE.domain.user.entity.User;
 import com.min.i.memory_BE.domain.user.service.JwtTokenProvider;
 import com.min.i.memory_BE.domain.user.service.UserService;
 import com.min.i.memory_BE.global.config.SecurityConfig;
-import jakarta.servlet.http.HttpServletRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -18,6 +27,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/auth")
@@ -34,46 +46,152 @@ public class LoginController {
     @Autowired
     private UserService userService;
 
+    @Operation(
+            summary = "로그인",
+            description = "사용자의 이메일과 비밀번호를 사용하여 로그인하고 JWT 토큰을 발급합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공",
+                    content = @Content(mediaType = "application/json")
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 실패 (잘못된 이메일 또는 비밀번호)"
+            ),
+            @ApiResponse(
+                    responseCode = "423",
+                    description = "계정 잠금 (로그인 시도 횟수 초과)"
+            )
+    })
     @PostMapping("/login")
-    public ResponseEntity<JwtAuthenticationResponse> login(@RequestBody UserLoginDto loginDto) {
-       try{
+    public ResponseEntity<String> login(@Parameter(description = "로그인에 필요한 사용자 이메일과 비밀번호")
+                                        @RequestBody UserLoginDto loginDto,
+                                        @Parameter(description = "HTTP 응답에 쿠키를 추가할 수 있도록 제공되는 HttpServletResponse 객체")
+                                        HttpServletResponse response) {
+        try {
+
+            // 로그인 실패 횟수 체크 (예시) - Brute-force attack (무차별 대입 공격) 방지
+            if (userService.isAccountLocked(loginDto.getEmail())) {
+                // 계정 잠금 상태가 있고, 잠금 시간이 남아있다면 그 정보를 함께 반환
+                User user = userService.getUserByEmail(loginDto.getEmail());
+                LocalDateTime lockedUntil = user.getLockedUntil();
+                long minutesLeft = Duration.between(LocalDateTime.now(), lockedUntil).toMinutes();
+
+                return ResponseEntity.status(HttpStatus.LOCKED)
+                        .body("계정이 잠겼습니다. " + minutesLeft + "분 후에 다시 시도해 주세요. 현재 로그인 시도 횟수: " + user.getLoginAttempts() + "회");
+            }
+
+            // 이메일과 비밀번호 검증
             Authentication authentication = authenticationManager.authenticate(
-                    new UsernamePasswordAuthenticationToken(
-                            loginDto.getEmail(),
-                            loginDto.getPassword()
-                    )
+                    new UsernamePasswordAuthenticationToken(loginDto.getEmail(), loginDto.getPassword())
             );
 
-           // 액세스 토큰 생성
-           String token = jwtTokenProvider.generateToken(loginDto.getEmail());
-           // 리프레시 토큰 생성
-           String refreshToken = jwtTokenProvider.generateRefreshToken(loginDto.getEmail());
+            // JWT 토큰 생성
+            JwtAuthenticationResponse tokens = userService.generateTokens(loginDto.getEmail());
 
-           // 토큰을 반환
-           logger.debug("생성된 토큰: {}", token);
-           return ResponseEntity.ok(new JwtAuthenticationResponse(token, refreshToken));
+            // JWT를 HttpOnly 쿠키에 저장 (ResponseCookie 사용)
+            ResponseCookie accessTokenCookie = ResponseCookie.from("jwtToken", tokens.getAccessToken())
+                    .httpOnly(true)
+                    .secure(true)  // HTTPS에서만 유효
+                    .path("/")  // 쿠키가 유효한 경로
+                    .maxAge(60 * 60)  // 만료 시간 1시간
+                    .sameSite("Strict")  // CSRF 방지를 위한 SameSite 설정
+                    .build();
 
-    } catch (Exception e) {
+            ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", tokens.getRefreshToken())
+                    .httpOnly(true)
+                    .secure(true)
+                    .path("/")
+                    .maxAge(60 * 60 * 24 * 30)
+                    .sameSite("Strict")
+                    .build();
+
+            // 쿠키에 추가
+            response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+            response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+            logger.debug("생성된 액세스 토큰: {}", tokens.getAccessToken());
+            logger.debug("생성된 리프레시 토큰: {}", tokens.getRefreshToken());
+
+            return ResponseEntity.ok("로그인 성공");
+
+        } catch (Exception e) {
             logger.error("로그인 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+
+            // 로그인 실패 시 로그인 시도 횟수 증가
+            userService.incrementLoginAttempts(loginDto.getEmail());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 실패");
         }
     }
 
+    @Operation(
+            summary = "로그아웃",
+            description = "로그아웃을 수행하고 JWT 토큰이 저장된 쿠키를 삭제합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "로그아웃 성공",
+            content = @Content(mediaType = "application/json")
+    )
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(HttpServletRequest request) {
-        // 클라이언트가 토큰 삭제하도록 알림
+    public ResponseEntity<String> logout(HttpServletResponse response) {
+
+        // 클라이언트가 JWT 쿠키를 삭제하도록 알림
+        Cookie cookie = new Cookie("jwtToken", null);
+        cookie.setHttpOnly(true); // 자바스크립트에서 접근 불가
+        cookie.setSecure(true); // HTTPS에서만 유효하도록 설정
+        cookie.setPath("/"); // 쿠키가 유효한 경로 설정
+        cookie.setMaxAge(0); // 쿠키 삭제
+        cookie.setComment("SameSite=Strict"); // CSRF 방지를 위한 SameSite 설정
+
+        Cookie refreshCookie = new Cookie("refreshToken", null);
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setSecure(true);
+        refreshCookie.setPath("/");
+        refreshCookie.setMaxAge(0);
+        cookie.setComment("SameSite=Strict");
+
+        response.addCookie(cookie);
+        response.addCookie(refreshCookie);
+
         return ResponseEntity.ok("로그아웃 성공");
     }
 
-    // 리프레시 토큰을 이용해 새로운 액세스 토큰 발급
+    @Operation(
+            summary = "리프레시 토큰을 이용해 새로운 액세스 토큰 발급",
+            description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "새로운 액세스 토큰 발급 성공",
+                    content = @Content(mediaType = "application/json")
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "리프레시 토큰이 유효하지 않음"
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류"
+            )
+    })
     @PostMapping("/refresh")
-    public ResponseEntity<JwtAuthenticationResponse> refresh(@RequestBody String refreshToken) {
-        if (jwtTokenProvider.validateRefreshToken(refreshToken)) {
-            String username = jwtTokenProvider.getUsernameFromToken(refreshToken);
-            String newToken = jwtTokenProvider.generateToken(username);
-            return ResponseEntity.ok(new JwtAuthenticationResponse(newToken, refreshToken));
-        } else {
-            return ResponseEntity.status(401).body(null); // 리프레시 토큰이 유효하지 않으면 401 응답
+    public ResponseEntity<JwtAuthenticationResponse> refresh(@Parameter(description = "리프레시 토큰")
+                                                             @RequestBody String refreshToken) {
+        try {
+            if (jwtTokenProvider.validateRefreshToken(refreshToken)) {
+                String username = jwtTokenProvider.getUsernameFromToken(refreshToken);
+                String newToken = jwtTokenProvider.generateToken(username);
+                return ResponseEntity.ok(new JwtAuthenticationResponse(newToken, refreshToken));
+            } else {
+                return ResponseEntity.status(401).body(null); // 리프레시 토큰이 유효하지 않으면 401 응답
+            }
+        } catch (Exception e) {
+            logger.error("리프레시 토큰 처리 중 오류 발생: {}", e.getMessage());
+            return ResponseEntity.status(500).body(null); // 서버 오류 처리
         }
     }
 

--- a/src/main/java/com/min/i/memory_BE/domain/user/controller/OAuthController.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/controller/OAuthController.java
@@ -2,12 +2,19 @@ package com.min.i.memory_BE.domain.user.controller;
 
 import com.min.i.memory_BE.domain.user.enums.OAuthProvider;
 import com.min.i.memory_BE.domain.user.service.OAuthService;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/oauth")
@@ -19,20 +26,138 @@ public class OAuthController {
         this.oAuthService = oAuthService;
     }
 
+    @Operation(
+            summary = "OAuth 로그인 리디렉션",
+            description = "사용자를 선택된 OAuth 제공자의 로그인 페이지로 리디렉션합니다."
+    )
+    @ApiResponse(
+            responseCode = "302",
+            description = "로그인 페이지로 리디렉션 성공",
+            content = @Content(mediaType = "application/json")
+    )
     @GetMapping("/login")
-    public ResponseEntity<Void> redirectToLogin(@RequestParam("provider") String providerName) {
+    public ResponseEntity<Void> redirectToLogin(@Parameter(description = "OAuth 제공자 이름 (예: google, kakao, naver)")
+                                                @RequestParam("provider") String providerName) {
         OAuthProvider provider = OAuthProvider.valueOf(providerName.toUpperCase());
         String authUrl = oAuthService.generateAuthUrl(provider);
         return ResponseEntity.status(HttpStatus.FOUND).header("Location", authUrl).build();
     }
 
+    @Operation(
+            summary = "OAuth 로그인 콜백 처리",
+            description = "OAuth 제공자로부터 받은 콜백을 처리하고 로그인 성공 메시지를 반환합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공",
+                    content = @Content(mediaType = "application/json")
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (잘못된 인증 코드 또는 상태)"
+            )
+    })
     @GetMapping("/callback")
-    public ResponseEntity<String> handleCallback(@RequestParam("provider") String providerName,
+    public ResponseEntity<String> handleCallback(@Parameter(description = "OAuth 제공자 이름 (예: google, kakao, naver)")
+                                                 @RequestParam("provider") String providerName,
+                                                 @Parameter(description = "OAuth 제공자가 반환한 인증 코드")
                                                  @RequestParam("code") String code,
+                                                 @Parameter(description = "상태 값 (선택 사항)")
                                                  @RequestParam(value = "state", required = false) String state) {
         OAuthProvider provider = OAuthProvider.valueOf(providerName.toUpperCase());
         oAuthService.handleCallback(provider, code, state);
         return ResponseEntity.ok(providerName + " 로그인 성공");
     }
+
+    @Operation(
+            summary = "OAuth 로그아웃",
+            description = "OAuth 제공자에서 로그아웃을 처리하고 세션을 무효화합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "로그아웃 성공",
+                    content = @Content(mediaType = "application/json")
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (잘못된 제공자 이름)"
+            )
+    })
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(
+            @Parameter(description = "로그아웃할 OAuth 제공자 이름 (예: google, kakao, naver)")
+            @RequestParam("provider") String provider,
+            @Parameter(description = "OAuth 제공자에서 발급된 액세스 토큰")
+            @RequestParam("token") String accessToken,
+            @Parameter(description = "HTTP 요청 객체")
+            HttpServletRequest request) {
+
+        // 서버 세션 무효화
+        request.getSession().invalidate();
+
+        // OAuth 제공자별 로그아웃 처리
+        switch (provider.toLowerCase()) {
+            case "google":
+                logoutFromGoogle(accessToken);
+                break;
+            case "kakao":
+                logoutFromKakao(accessToken);
+                break;
+            case "naver":
+                logoutFromNaver(); // 네이버는 서버 세션 무효화만 처리
+                break;
+            default:
+                throw new IllegalArgumentException("지원하지 않는 제공자: " + provider);
+        }
+
+        // 로그아웃 완료 메시지만 반환하고 리다이렉트는 프론트에서 처리
+        return ResponseEntity.ok("로그아웃 완료");
+    }
+
+    private void logoutFromGoogle(String accessToken) {
+        RestTemplate restTemplate = new RestTemplate();
+        String revokeUrl = "https://accounts.google.com/o/oauth2/revoke?token=" + accessToken;
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                revokeUrl,
+                HttpMethod.GET,
+                null,
+                String.class
+        );
+
+        if (response.getStatusCode() != HttpStatus.OK) {
+            throw new RuntimeException("Failed to revoke Google token");
+        }
+    }
+
+    private void logoutFromKakao(String accessToken) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+
+        HttpEntity<String> request = new HttpEntity<>(headers);
+        String logoutUrl = "https://kapi.kakao.com/v1/user/logout";
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                logoutUrl,
+                HttpMethod.POST,
+                request,
+                new ParameterizedTypeReference<>() {
+                }
+        );
+
+        if (response.getStatusCode() != HttpStatus.OK) {
+            throw new RuntimeException("Failed to logout from Kakao");
+        }
+    }
+
+    private void logoutFromNaver() {
+        // 네이버는 별도의 로그아웃 API가 없음
+        // 이미 위에서 request.getSession().invalidate()로 처리됨
+        System.out.println("Naver session 무효화됨");
+    }
+
 }
 

--- a/src/main/java/com/min/i/memory_BE/domain/user/controller/RegisterController.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/controller/RegisterController.java
@@ -1,0 +1,130 @@
+package com.min.i.memory_BE.domain.user.controller;
+
+import com.min.i.memory_BE.domain.user.dto.UserRegisterDto;
+import com.min.i.memory_BE.domain.user.dto.UserRegisterResultDto;
+import com.min.i.memory_BE.domain.user.service.EmailService;
+import com.min.i.memory_BE.domain.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/register")
+public class RegisterController {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private EmailService emailService;
+
+    // 이메일 인증 코드 발송
+    @Operation(
+            summary = "이메일 인증 코드 발송",
+            description = "사용자에게 이메일 인증 코드를 전송하고, JWT 토큰을 생성하여 반환합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "인증 코드 전송 성공",
+                    content = @Content(mediaType = "application/json")
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "이메일 전송 실패"
+            )
+    })
+    @PostMapping("/send-verification-code")
+    public ResponseEntity<String> sendVerificationCode(@Parameter(description = "인증코드를 받을 이메일 주소")
+                                                       @RequestBody UserRegisterDto userRegisterDto) {
+        // JWT 생성 및 이메일 전송
+        String jwt = emailService.sendVerificationCode(userRegisterDto);
+
+        System.out.println("인증 코드가 이메일로 전송되었습니다. JWT: " + jwt);
+
+        if (jwt != null) {
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwt)
+                    .body("인증 코드가 이메일로 전송되었습니다.");
+        } else {
+            return ResponseEntity.status(500).body("이메일 전송에 실패했습니다.");
+        }
+    }
+
+    @Operation(
+            summary = "이메일 인증",
+            description = "사용자가 전송된 이메일 인증 코드를 사용하여 이메일을 인증합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "이메일 인증 성공",
+                    content = @Content(mediaType = "application/json")
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "이메일 인증 실패 (인증 코드 오류)"
+            )
+    })
+    @PostMapping("/verify-email")
+    public ResponseEntity<String> verifyEmail(@Parameter(description = "이메일로 받은 인증 코드")
+                                              @RequestBody UserRegisterDto userRegisterDto,
+                                              @Parameter(description = "Authorization 헤더에 포함된 JWT 토큰")
+                                              @RequestHeader("Authorization") String authorization) {
+        // JWT 토큰 추출 (Bearer 토큰에서 실제 JWT 값을 추출)
+        String jwtToken = authorization.replace("Bearer ", "");
+
+        // JWT 유효성 검사 후 이메일 인증
+        String newJwt = userService.verifyEmail(jwtToken, userRegisterDto.getEmailVerificationCode());
+
+        // JWT 출력 (서버 로그에 출력)
+        System.out.println("이메일 인증에 성공했습니다. New JWT: " + newJwt);
+
+        //인증 성공 시 새로운 JWT를 Authorization 헤더에 포함시켜 반환
+        if (newJwt != null) {
+            return ResponseEntity
+                    .ok()
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtToken)
+                    .body("이메일 인증 성공");
+        } else {
+            return ResponseEntity.status(400).body("이메일 인증에 실패했습니다. 인증 코드를 다시 확인하세요.");
+        }
+    }
+
+    @Operation(
+            summary = "최종 회원가입 처리",
+            description = "인증된 이메일로 최종 회원가입을 완료합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "회원가입 완료",
+                    content = @Content(mediaType = "application/json")
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "회원가입 실패 (잘못된 JWT 토큰 또는 사용자 정보)"
+            )
+    })
+    @PostMapping("/complete-register")
+    public ResponseEntity<String> completeRegister(@Parameter(description = "회원가입에 필요한 추가 사용자 정보(비밀번호, 이름, 프로필 사진 링크)")
+                                                   @RequestBody UserRegisterDto userRegisterDto,
+                                                   @Parameter(description = "Authorization 헤더에 포함된 JWT 토큰")
+                                                   @RequestHeader("Authorization") String authorization) {
+
+        // JWT 토큰 추출 (Bearer 토큰에서 실제 JWT 값을 추출)
+        String jwtToken = authorization.replace("Bearer ", "");
+
+        // 인증된 이메일로 최종 회원가입 처리
+        UserRegisterResultDto result = userService.completeRegister(userRegisterDto, jwtToken);
+
+        return ResponseEntity.ok(result.getMessage());
+    }
+
+}

--- a/src/main/java/com/min/i/memory_BE/domain/user/controller/UserController.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/controller/UserController.java
@@ -1,81 +1,61 @@
 package com.min.i.memory_BE.domain.user.controller;
 
-import com.min.i.memory_BE.domain.user.dto.UserRegisterDto;
-import com.min.i.memory_BE.domain.user.dto.UserRegisterResultDto;
-import com.min.i.memory_BE.domain.user.service.EmailService;
-import com.min.i.memory_BE.domain.user.service.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/user")
 public class UserController {
 
-    @Autowired
-    private UserService userService;
-
-    @Autowired
-    private EmailService emailService;
-
-    // 이메일 인증 코드 발송
-    @PostMapping("/send-verification-code")
-    public ResponseEntity<String> sendVerificationCode(@RequestBody UserRegisterDto userRegisterDto) {
-        // JWT 생성 및 이메일 전송
-        String jwt = emailService.sendVerificationCode(userRegisterDto);
-
-        if (jwt != null) {
-            return ResponseEntity.ok("인증 코드가 이메일로 전송되었습니다. JWT: " + jwt);
-        } else {
-            return ResponseEntity.status(500).body("이메일 전송에 실패했습니다.");
-        }
-    }
-
-    @PostMapping("/verify-email")
-    public ResponseEntity<String> verifyEmail(@RequestBody UserRegisterDto userRegisterDto,
-                                              @RequestHeader("Authorization") String authorization) {
-        // JWT 토큰 추출 (Bearer 토큰에서 실제 JWT 값을 추출)
-        String jwtToken = authorization.replace("Bearer ", "");
-
-        // JWT 유효성 검사 후 이메일 인증
-        String newJwt = userService.verifyEmail(jwtToken, userRegisterDto.getEmailVerificationCode());
-
-        if (newJwt != null) {
-            return ResponseEntity.ok("이메일 인증에 성공했습니다. New JWT: " + newJwt);
-        } else {
-            return ResponseEntity.status(400).body("이메일 인증에 실패했습니다. 인증 코드를 다시 확인하세요.");
-        }
-    }
-
-    // 사용자 정보 추가 입력 후 최종 회원가입 처리
-    @PostMapping("/complete-register")
-    public ResponseEntity<String> completeRegister(@RequestBody UserRegisterDto userRegisterDto, @RequestHeader("Authorization") String authorization) {
-
-        // JWT 토큰 추출 (Bearer 토큰에서 실제 JWT 값을 추출)
-        String jwtToken = authorization.replace("Bearer ", "");
-
-        // 인증된 이메일로 최종 회원가입 처리
-        UserRegisterResultDto result = userService.completeRegister(userRegisterDto, jwtToken);
-
-        return ResponseEntity.ok(result.getMessage());
-    }
-
-
-    // 로그인 페이지
+    @Operation(
+            summary = "로그인 페이지로 이동",
+            description = "사용자를 로그인 페이지로 리디렉션합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "로그인 페이지로 이동"
+    )
     @GetMapping("/loginPage")
     public ResponseEntity<String> loginPage() {
         return ResponseEntity.ok("로그인 페이지로 이동");
-
     }
+//
 
-    // 홈 페이지
+    @Operation(
+            summary = "홈 페이지로 이동",
+            description = "사용자를 홈 페이지로 리디렉션합니다. 인증된 사용자만 홈 페이지로 이동할 수 있습니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "홈 페이지로 이동"
+    )
     @GetMapping("/home")
     public ResponseEntity<String> homePage() {
         return ResponseEntity.ok("홈으로 이동");
     }
+//
 
-    // 마이 페이지
+    @Operation(
+            summary = "마이 페이지로 이동",
+            description = "인증된 사용자만 마이 페이지로 이동할 수 있습니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "마이 페이지로 이동",
+                    content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json")
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요"
+            )
+    })
     @GetMapping("/my-page")
     public ResponseEntity<String> myPage(Authentication auth) {
         if (auth != null && auth.isAuthenticated()) {
@@ -84,4 +64,5 @@ public class UserController {
             return ResponseEntity.status(401).body("로그인 필요");
         }
     }
+
 }

--- a/src/main/java/com/min/i/memory_BE/domain/user/entity/User.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/entity/User.java
@@ -3,10 +3,7 @@ package com.min.i.memory_BE.domain.user.entity;
 import com.min.i.memory_BE.domain.group.entity.UserGroup;
 import com.min.i.memory_BE.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -35,24 +32,41 @@ public class User extends BaseEntity {
   private boolean emailVerified = false;
 
   private String emailVerificationCode;
-  
-  private LocalDateTime emailVerificationExpiredAt;// 유효기간
-  
+
+  // 이메일 인증 코드 유효기간
+  private LocalDateTime emailVerificationExpiredAt;
+
+  // 로그인 시도 횟수
+  private int loginAttempts = 0;  // 기본값 0
+
+  // 계정 잠금 여부
+  private boolean accountLocked = false;
+
+  // 마지막 로그인 시도 시간
+  private LocalDateTime lastLoginAttempt;
+
+  // 계정 잠금 해제까지 남은 시간
+  private LocalDateTime lockedUntil;
+
   @OneToMany(mappedBy = "user")
   private final List<OAuthAccount> oauthAccounts = new ArrayList<>();
   
   @OneToMany(mappedBy = "user")
   private final List<UserGroup> userGroups = new ArrayList<>();
   
-  @Builder
-  public User(String email, String password, String name, boolean emailVerified, String profileImageUrl, String emailVerificationCode,
-    LocalDateTime emailVerificationExpiredAt) {
+  @Builder(toBuilder = true)  // toBuilder 활성화
+  public User(String email, String password, String name, boolean emailVerified, String profileImgUrl, String emailVerificationCode,
+    LocalDateTime emailVerificationExpiredAt, int loginAttempts, boolean accountLocked, LocalDateTime lastLoginAttempt, LocalDateTime lockedUntil) {
     this.email = email;
     this.password = password;
     this.name = name;
-    this.profileImgUrl = profileImageUrl;
+    this.profileImgUrl = profileImgUrl;
     this.emailVerified = emailVerified;
     this.emailVerificationCode = emailVerificationCode;
     this.emailVerificationExpiredAt = emailVerificationExpiredAt;
+    this.loginAttempts = loginAttempts;
+    this.accountLocked = accountLocked;
+    this.lastLoginAttempt = lastLoginAttempt;
+    this.lockedUntil = lockedUntil;
   }
 }

--- a/src/main/java/com/min/i/memory_BE/domain/user/service/OAuthService.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/service/OAuthService.java
@@ -145,7 +145,8 @@ public class OAuthService {
                 tokenRequestUrl,
                 HttpMethod.POST,
                 null,
-                new ParameterizedTypeReference<>() {}
+                new ParameterizedTypeReference<>() {
+                }
         );
 
         Map<String, Object> responseBody = response.getBody();
@@ -173,7 +174,8 @@ public class OAuthService {
                 tokenRequestUrl,
                 HttpMethod.POST,
                 entity,
-                new ParameterizedTypeReference<>() {}
+                new ParameterizedTypeReference<>() {
+                }
         );
 
         Map<String, Object> responseBody = response.getBody();
@@ -202,7 +204,8 @@ public class OAuthService {
                 googleTokenUrl,
                 HttpMethod.POST,
                 request,
-                new ParameterizedTypeReference<>() {}
+                new ParameterizedTypeReference<>() {
+                }
         );
 
         Map<String, Object> responseBody = response.getBody();
@@ -238,7 +241,8 @@ public class OAuthService {
                 profileUrl,
                 HttpMethod.GET,
                 entity,
-                new ParameterizedTypeReference<>() {}
+                new ParameterizedTypeReference<>() {
+                }
         );
 
         Map<String, Object> userProfile = response.getBody();
@@ -248,6 +252,7 @@ public class OAuthService {
 
         saveOrUpdateUser(userProfile, provider, accessToken);
     }
+
     private void saveOrUpdateUser(Map<String, Object> userProfile, OAuthProvider provider, String accessToken) {
         String providerUserId;
         String email = null;
@@ -295,8 +300,8 @@ public class OAuthService {
                 User newUser = User.builder()
                         .email(finalEmail)
                         .name(finalName)
-                        .profileImageUrl(finalProfileImgUrl)
-                        .emailVerified(finalEmail  != null && !finalEmail .isEmpty())
+                        .profileImgUrl(finalProfileImgUrl)
+                        .emailVerified(finalEmail != null && !finalEmail.isEmpty())
                         .build();
                 return userRepository.save(newUser);
             });

--- a/src/main/java/com/min/i/memory_BE/global/config/SecurityConfig.java
+++ b/src/main/java/com/min/i/memory_BE/global/config/SecurityConfig.java
@@ -21,72 +21,73 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 public class SecurityConfig {
 
-  private static final Logger logger = LoggerFactory.getLogger(SecurityConfig.class);
+    private static final Logger logger = LoggerFactory.getLogger(SecurityConfig.class);
 
-  @Autowired
-  private MyUserDetailsService myUserDetailsService;
+    @Autowired
+    private MyUserDetailsService myUserDetailsService;
 
-  @Autowired
-  private PasswordEncoder passwordEncoder;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
-  @Autowired
-  private JwtTokenProvider jwtTokenProvider;
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
 
-  @Bean
-  public JWTAuthenticationFilter jwtAuthenticationFilter() {
-    return new JWTAuthenticationFilter(jwtTokenProvider);  // JWTAuthenticationFilter를 빈으로 등록
-  }
+    @Bean
+    public JWTAuthenticationFilter jwtAuthenticationFilter() {
+        return new JWTAuthenticationFilter(jwtTokenProvider);  // JWTAuthenticationFilter를 빈으로 등록
+    }
 
-  @Bean
-  public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
-    return http.getSharedObject(AuthenticationManagerBuilder.class)
-            .userDetailsService(myUserDetailsService)
-            .passwordEncoder(passwordEncoder)
-            .and()
-            .build();
-  }
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+        return http.getSharedObject(AuthenticationManagerBuilder.class)
+                .userDetailsService(myUserDetailsService)
+                .passwordEncoder(passwordEncoder)
+                .and()
+                .build();
+    }
 
-  @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http
-            .csrf().disable()  // CSRF 보호 비활성화
-            .authorizeRequests()
-              .requestMatchers("/h2-console/**" ,"/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/api/v1/mock/**", "/user/send-verification-code", "/user/verify-email", "/user/complete-register")  // 로그인 및 회원가입 URL은 인증 없이 접근 허용
-              .permitAll()
-              .requestMatchers("/oauth/callback").permitAll()// 로그인 URL을 인증 없이 접근 허용
-              .requestMatchers("/oauth/login").permitAll()
-              .requestMatchers("/auth/login").permitAll()  // 로그인 URL을 인증 없이 접근 허용
-              .requestMatchers("/user/home").authenticated()// 홈 페이지는 로그인한 사용자만 접근 가능
-              .requestMatchers("/user/my-page").authenticated()  // 마이 페이지도 로그인한 사용자만 접근 가능
-              .anyRequest().authenticated()  // 그 외 모든 요청은 인증 필요
-            .and()
-            .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)  // JWT 필터 추가
-            .logout()
-              .logoutUrl("/logout")
-              .logoutSuccessUrl("/login?logout")
-              .invalidateHttpSession(true)  // 세션 무효화
-              .deleteCookies("JSESSIONID")  // 쿠키 삭제
-              .permitAll()
-            .and()
-            // X-Frame-Options를 허용하도록 설정
-            .headers()
-            .frameOptions().sameOrigin();  // H2 콘솔이 iframe 안에서 실행되도록 설정
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()  // CSRF 보호 비활성화
+                .authorizeRequests()
+                .requestMatchers("/h2-console/**", "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/api/v1/mock/**", "/register/send-verification-code", "/user/loginPage")  // 로그인 및 회원가입 URL은 인증 없이 접근 허용
+                .permitAll()
+                .requestMatchers("/oauth/callback").permitAll()
+                .requestMatchers("/oauth/login").permitAll() // 로그인 URL을 인증 없이 접근 허용
+                .requestMatchers("/auth/login").permitAll()
+                .requestMatchers("/register/verify-email", "/register/complete-register").permitAll() // 이메일 인증 및 회원가입은 인증이 필요
+                .requestMatchers("/user/home").authenticated() // 홈 페이지는 로그인한 사용자만 접근 가능
+                .requestMatchers("/user/my-page").authenticated()  // 마이 페이지도 로그인한 사용자만 접근 가능
+                .anyRequest().authenticated()  // 그 외 모든 요청은 인증 필요
+                .and()
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)  // JWT 필터 추가
+                .logout()
+                .logoutUrl("/logout")
+                .logoutSuccessUrl("/login?logout")
+                .invalidateHttpSession(true)  // 세션 무효화
+                .deleteCookies("JSESSIONID")  // 쿠키 삭제
+                .permitAll()
+                .and()
+                // X-Frame-Options를 허용하도록 설정
+                .headers()
+                .frameOptions().sameOrigin();  // H2 콘솔이 iframe 안에서 실행되도록 설정
 
-    return http.build();
-  }
+        return http.build();
+    }
 
-  @Autowired
-  public void configure(AuthenticationManagerBuilder auth) throws Exception {
-    auth.userDetailsService(myUserDetailsService).passwordEncoder(passwordEncoder);  // PasswordEncoder를 사용
-  }
+    @Autowired
+    public void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth.userDetailsService(myUserDetailsService).passwordEncoder(passwordEncoder);  // PasswordEncoder를 사용
+    }
 
-  @Bean
-  public AuthenticationFailureHandler authenticationFailureHandler() {
-    return (request, response, exception) -> {
-      logger.error("로그인 실패: {}", exception.getMessage());  // 로그인 실패 이유를 로그에 출력
-      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-      response.getWriter().write("로그인에 실패했습니다. 다시 시도해 주세요.");
-    };
-  }
+    @Bean
+    public AuthenticationFailureHandler authenticationFailureHandler() {
+        return (request, response, exception) -> {
+            logger.error("로그인 실패: {}", exception.getMessage());  // 로그인 실패 이유를 로그에 출력
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("로그인에 실패했습니다. 다시 시도해 주세요.");
+        };
+    }
 
 }


### PR DESCRIPTION
-로그인 실패 5회 초과 시 계정 잠금 기능 추가
 - 잠금 30분 후 로그인 시도 가능
-로그아웃 시 JWT와 리프레시 토큰을 쿠키에서 삭제
- 각 API 메서드에 Swagger UI 설명 추가
 - `@Operation`, `@Parameter`를 사용하여 API 설명과 파라미터 설명 추가
 - `@ApiResponse`를 통해 응답 코드 및 설명 추가