### PR TITLE
feat: 사용자 계정 관리 기능 구현

### DIFF
--- a/src/main/java/com/min/i/memory_BE/domain/user/controller/UserController.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/controller/UserController.java
@@ -1,17 +1,23 @@
 package com.min.i.memory_BE.domain.user.controller;
 
+import com.min.i.memory_BE.domain.user.entity.User;
+import com.min.i.memory_BE.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/user")
 public class UserController {
+
+    @Autowired
+    private UserService userService;
 
     @Operation(
             summary = "로그인 페이지로 이동",
@@ -29,7 +35,7 @@ public class UserController {
 
     @Operation(
             summary = "홈 페이지로 이동",
-            description = "사용자를 홈 페이지로 리디렉션합니다. 인증된 사용자만 홈 페이지로 이동할 수 있습니다."
+            description = "사용자를 홈 페이지로 리디렉션합니다. 로그인된 사용자만 홈 페이지로 이동할 수 있습니다."
     )
     @ApiResponse(
             responseCode = "200",
@@ -43,7 +49,7 @@ public class UserController {
 
     @Operation(
             summary = "마이 페이지로 이동",
-            description = "인증된 사용자만 마이 페이지로 이동할 수 있습니다."
+            description = "사용자를 마이 페이지로 리디렉션합니다. 로그인된 사용자만 마이 페이지로 이동할 수 있습니다."
     )
     @ApiResponses(value = {
             @ApiResponse(
@@ -65,4 +71,155 @@ public class UserController {
         }
     }
 
+    // 사용자 정보 수정
+    @Operation(
+            summary = "사용자 정보 수정",
+            description = "사용자가 비밀번호, 이름, 프로필 사진 링크, 이메일을 수정합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "사용자 정보 수정 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청"
+            )
+    })
+    @PutMapping("/update")
+    public ResponseEntity<String> updateUser(
+            @Parameter(description = "사용자가 수정할 이메일") @RequestParam String email,
+            @Parameter(description = "사용자가 수정할 비밀번호") @RequestParam(required = false) String password,
+            @Parameter(description = "사용자가 수정할 이름") @RequestParam(required = false) String name,
+            @Parameter(description = "사용자가 수정할 프로필 사진 URL") @RequestParam(required = false) String profileImgUrl,
+            Authentication auth) {
+        if (auth != null && auth.isAuthenticated()) {
+            User updatedUser = userService.updateUser(email, password, name, profileImgUrl);
+            return ResponseEntity.ok("사용자 정보가 성공적으로 수정되었습니다.");
+        } else {
+            return ResponseEntity.status(401).body("로그인 필요");
+        }
+    }
+
+    // 사용자 탈퇴 (계정 영구 삭제)
+    @Operation(
+            summary = "사용자 탈퇴",
+            description = "사용자가 탈퇴하면 계정이 삭제됩니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "탈퇴 처리 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (이메일 형식 오류)"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요"
+            )
+    })
+    @DeleteMapping("/delete")
+    public ResponseEntity<String> deleteUser(@Parameter(description = "사용자 이메일") @RequestParam String email, Authentication auth) {
+        if (auth == null || !auth.isAuthenticated()) {
+            return ResponseEntity.status(401).body("로그인이 필요합니다.");
+        }
+
+        try {
+            userService.deleteUser(email);
+            return ResponseEntity.ok("사용자 탈퇴가 완료되었습니다.");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body("사용자를 찾을 수 없습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(400).body("잘못된 요청입니다.");
+        }
+    }
+
+    // 사용자 계정 비활성화
+    @Operation(
+            summary = "사용자 계정 비활성화",
+            description = "사용자가 계정을 비활성화하면 상태가 '비활성'으로 변경됩니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "계정 비활성화 처리 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (이메일 형식 오류)"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요"
+            )
+    })
+    @PostMapping("/deactivate")
+    public ResponseEntity<String> deactivateUser(@Parameter(description = "사용자 이메일") @RequestParam String email, Authentication auth) {
+        if (auth == null || !auth.isAuthenticated()) {
+            return ResponseEntity.status(401).body("로그인이 필요합니다.");
+        }
+
+        try {
+            userService.deactivateUser(email);
+            return ResponseEntity.ok("사용자 계정이 비활성화되었습니다.");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body("사용자를 찾을 수 없습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(400).body("잘못된 요청입니다.");
+        }
+    }
+
+    // 사용자 계정 활성화
+    @Operation(
+            summary = "사용자 계정 활성화",
+            description = "사용자가 비활성화된 계정을 활성화합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "계정 활성화 처리 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (이메일 형식 오류)"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요"
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "비활성화되지 않은 계정은 활성화할 수 없습니다."
+            )
+    })
+    @PostMapping("/activate")
+    public ResponseEntity<String> activateUser(@Parameter(description = "사용자 이메일") @RequestParam String email, Authentication auth) {
+        if (auth == null || !auth.isAuthenticated()) {
+            return ResponseEntity.status(401).body("로그인이 필요합니다.");
+        }
+
+        try {
+            userService.activateUser(email);
+            return ResponseEntity.ok("사용자 계정이 활성화되었습니다.");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body("사용자를 찾을 수 없습니다.");
+        } catch (Exception e) {
+            //이미 활성화된 계정은 활성화 작업이 필요없어서 요청을 보낼 때 충돌이 발생! (=상태의 불일치)
+            return ResponseEntity.status(409).body("비활성화된 계정만 활성화할 수 있습니다.");
+        }
+    }
 }

--- a/src/main/java/com/min/i/memory_BE/domain/user/entity/User.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.min.i.memory_BE.domain.user.entity;
 
 import com.min.i.memory_BE.domain.group.entity.UserGroup;
+import com.min.i.memory_BE.domain.user.enums.UserStatus;
 import com.min.i.memory_BE.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -48,6 +49,11 @@ public class User extends BaseEntity {
   // 계정 잠금 해제까지 남은 시간
   private LocalDateTime lockedUntil;
 
+  // 사용자 상태 (활성, 비활성, 삭제됨)
+  @Enumerated(EnumType.STRING)  // 열거형을 DB에 문자열로 저장
+  @Column(nullable = false)
+  private UserStatus status = UserStatus.ACTIVE;  // 기본값을 'ACTIVE'로 설정
+
   @OneToMany(mappedBy = "user")
   private final List<OAuthAccount> oauthAccounts = new ArrayList<>();
   
@@ -56,7 +62,7 @@ public class User extends BaseEntity {
   
   @Builder(toBuilder = true)  // toBuilder 활성화
   public User(String email, String password, String name, boolean emailVerified, String profileImgUrl, String emailVerificationCode,
-    LocalDateTime emailVerificationExpiredAt, int loginAttempts, boolean accountLocked, LocalDateTime lastLoginAttempt, LocalDateTime lockedUntil) {
+    LocalDateTime emailVerificationExpiredAt, int loginAttempts, boolean accountLocked, LocalDateTime lastLoginAttempt, LocalDateTime lockedUntil, UserStatus status) {
     this.email = email;
     this.password = password;
     this.name = name;
@@ -68,5 +74,6 @@ public class User extends BaseEntity {
     this.accountLocked = accountLocked;
     this.lastLoginAttempt = lastLoginAttempt;
     this.lockedUntil = lockedUntil;
+    this.status = status != null ? status : UserStatus.ACTIVE;  // 기본값을 ACTIVE로 설정
   }
 }

--- a/src/main/java/com/min/i/memory_BE/domain/user/enums/UserStatus.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/enums/UserStatus.java
@@ -5,8 +5,7 @@ import lombok.Getter;
 @Getter
 public enum UserStatus {
   ACTIVE("활성"),
-  INACTIVE("비활성"),
-  DELETED("삭제됨");
+  INACTIVE("비활성");
   
   private final String description;
   

--- a/src/main/java/com/min/i/memory_BE/domain/user/service/EmailService.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/service/EmailService.java
@@ -1,7 +1,6 @@
 package com.min.i.memory_BE.domain.user.service;
 
 import com.min.i.memory_BE.domain.user.dto.UserRegisterDto;
-import com.min.i.memory_BE.domain.user.repository.UserRepository;
 import com.min.i.memory_BE.global.config.MailConfig;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -26,9 +25,6 @@ public class EmailService {
     @Autowired
     @Qualifier("naverMailSender")
     private JavaMailSender naverMailSender; // 네이버 전용 JavaMailSender
-
-    @Autowired
-    private UserRepository userRepository; // UserRepository를 사용해 이메일 인증 코드 및 유효 기간을 저장
 
     @Autowired
     private MailConfig mailConfig;  // MailConfig를 주입받아 fromEmail을 동적으로 설정

--- a/src/main/java/com/min/i/memory_BE/global/config/JWTAuthenticationFilter.java
+++ b/src/main/java/com/min/i/memory_BE/global/config/JWTAuthenticationFilter.java
@@ -18,11 +18,13 @@ import java.util.Collections;
 
 public class JWTAuthenticationFilter  extends OncePerRequestFilter {
 
+    //JWT를 사용하여 요청이 들어올 때마다 인증을 처리하는 필터 - 인증된 사용자인지 확인하고, 그에 맞는 권한을 부여함.
+
     private final JwtTokenProvider jwtTokenProvider;  // JwtTokenProvider를 주입받음
 
-    @Autowired
+    @Autowired //각 요청마다 한 번만 실행되도록 보장
     public JWTAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
-        this.jwtTokenProvider = jwtTokenProvider;
+        this.jwtTokenProvider = jwtTokenProvider; //JWT 토큰을 발급하고 검증
     }
 
     @Override
@@ -30,29 +32,39 @@ public class JWTAuthenticationFilter  extends OncePerRequestFilter {
             throws ServletException, IOException {
 
         String requestURI = request.getRequestURI();
-        // JWT 필터가 실행되는 경로를 제외
+
+        // "/auth/login" 경로에 대해서는 필터를 적용하지 않음
         if ("/auth/login".equals(requestURI)) {
             chain.doFilter(request, response);
             return;
         }
 
+        //요청 헤더에서 JWT 토큰을 추출
         String token = getTokenFromRequest(request);
 
+        //추출한 토큰이 유효하다면, JwtTokenProvider를 사용하여 토큰을 검증, 토큰에서 사용자 정보를 추출
         if (token != null && jwtTokenProvider.validateToken(token)) {
             String username = jwtTokenProvider.getUsernameFromToken(token);
 
+            //추출한 사용자 정보로 UsernamePasswordAuthenticationToken 생성,
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                     username, null, Collections.singletonList(new SimpleGrantedAuthority("USER"))
             );
             authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+            //Spring Security의 SecurityContext에 설정하여 인증된 사용자로 처리
+            //이후 이 정보를 바탕으로 인증 및 권한 부여가 이루어짐! = 즉 로그인 여부로 특정 페이지 접근 등을 제한 할 수 있음
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 
         chain.doFilter(request, response);
     }
 
+    //요청 헤더에서 "Bearer "로 시작하는 JWT 토큰을 추출
     private String getTokenFromRequest(HttpServletRequest request) {
         String header = request.getHeader("Authorization");
+
+        //"Bearer "라는 접두어 제거, 실제 토큰 반환
         if (header != null && header.startsWith("Bearer ")) {
             return header.substring(7); // "Bearer " 제거
         }


### PR DESCRIPTION
- 사용자 계정 활성화, 비활성화, 탈퇴 기능 구현
- 로그인된 사용자만 계정 활성화, 비활성화, 탈퇴 가능하도록 보안 설정
- 'UserStatus' enum을 활용하여 사용자 상태 관리 ('ACTIVE(활성화)', 'INACTIVE(비활성화)')
- Swagger UI에 각 API 응답 코드 및 설명 추가 (200, 401, 404, 400, 409 등..)
