### PR TITLE
fix : OAuth logout & fix CORS config

### DIFF
--- a/src/main/java/com/min/i/memory_BE/domain/user/controller/UserController.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/controller/UserController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/min/i/memory_BE/domain/user/entity/User.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/entity/User.java
@@ -26,7 +26,8 @@ public class User extends BaseEntity {
   
   @Column(nullable = false)
   private String name;
-  
+
+  @Column(nullable = false)
   private String profileImgUrl;
 
   @Column(nullable = false)

--- a/src/main/java/com/min/i/memory_BE/global/config/JWTAuthenticationFilter.java
+++ b/src/main/java/com/min/i/memory_BE/global/config/JWTAuthenticationFilter.java
@@ -22,12 +22,12 @@ public class JWTAuthenticationFilter  extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;  // JwtTokenProvider를 주입받음
 
-    @Autowired //각 요청마다 한 번만 실행되도록 보장
+    @Autowired
     public JWTAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
         this.jwtTokenProvider = jwtTokenProvider; //JWT 토큰을 발급하고 검증
     }
 
-    @Override
+    @Override //HTTP 요청을 처리
     public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
 
@@ -46,7 +46,7 @@ public class JWTAuthenticationFilter  extends OncePerRequestFilter {
         if (token != null && jwtTokenProvider.validateToken(token)) {
             String username = jwtTokenProvider.getUsernameFromToken(token);
 
-            //추출한 사용자 정보로 UsernamePasswordAuthenticationToken 생성,
+            //추출한 사용자 정보로 UsernamePasswordAuthenticationToken 생성
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                     username, null, Collections.singletonList(new SimpleGrantedAuthority("USER"))
             );

--- a/src/main/java/com/min/i/memory_BE/global/config/WebConfig.java
+++ b/src/main/java/com/min/i/memory_BE/global/config/WebConfig.java
@@ -18,7 +18,27 @@ public class WebConfig implements WebMvcConfigurer {
             .allowedOrigins("http://localhost:3000")
             .allowedMethods("*")
             .allowedHeaders("*");
+
+    // 추가: /user/** 경로에도 CORS 허용
+    registry.addMapping("/register/**")
+            .allowedOrigins("http://localhost:3000")
+            .allowedMethods("*")
+            .allowedHeaders("*");
+
+    // 추가: /user/** 경로에도 CORS 허용
+    registry.addMapping("/auth/**")
+            .allowedOrigins("http://localhost:3000")
+            .allowedMethods("*")
+            .allowedHeaders("*");
+
+    // 추가: /user/** 경로에도 CORS 허용
+    registry.addMapping("/oauth/**")
+            .allowedOrigins("http://localhost:3000")
+            .allowedMethods("*")
+            .allowedHeaders("*");
   }
+
+
 
 
 }


### PR DESCRIPTION
- Spring Security 설정 업데이트: `/auth/logout`은 POST 방식, `/oauth/logout`은 GET 방식 요청 지원
- 일반 로그아웃과 OAuth 로그아웃 설정을 분리하여 SecurityConfig 리팩토링
- 회원 관련 요청 경로 CORS 설정 허용