### PR TITLE
fix: 로그인 실패 처리 및 이메일 중복 문제 해결

### DIFF
--- a/src/main/java/com/min/i/memory_BE/domain/user/controller/LoginController.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/controller/LoginController.java
@@ -21,6 +21,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -72,15 +73,22 @@ public class LoginController {
                                         HttpServletResponse response) {
         try {
 
-            // 로그인 실패 횟수 체크 (예시) - Brute-force attack (무차별 대입 공격) 방지
+            // 이메일이 존재하는지 확인
+            User user = userService.getUserByEmail(loginDto.getEmail());
+            if (user == null) {
+                // 이메일이 존재하지 않으면 로그인 실패 처리
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body("없는 이메일입니다.");
+            }
+
+            // 로그인 실패 횟수 체크 - Brute-force attack (무차별 대입 공격) 방지
             if (userService.isAccountLocked(loginDto.getEmail())) {
                 // 계정 잠금 상태가 있고, 잠금 시간이 남아있다면 그 정보를 함께 반환
-                User user = userService.getUserByEmail(loginDto.getEmail());
                 LocalDateTime lockedUntil = user.getLockedUntil();
                 long minutesLeft = Duration.between(LocalDateTime.now(), lockedUntil).toMinutes();
 
                 return ResponseEntity.status(HttpStatus.LOCKED)
-                        .body("계정이 잠겼습니다. " + minutesLeft + "분 후에 다시 시도해 주세요. 현재 로그인 시도 횟수: " + user.getLoginAttempts() + "회");
+                        .body("계정이 잠겼습니다. " + minutesLeft + "분 후에 다시 시도해 주세요.");
             }
 
             // 이메일과 비밀번호 검증
@@ -117,12 +125,20 @@ public class LoginController {
 
             return ResponseEntity.ok("로그인 성공");
 
+        } catch (BadCredentialsException e) {
+            // 비밀번호가 틀리면 로그인 실패 시 로그인 시도 횟수 증가
+            int loginAttempts = userService.incrementLoginAttempts(loginDto.getEmail());
+
+            // 로그인 시도 횟수 반환
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body("비밀번호가 틀렸습니다. 현재 로그인 시도 횟수: " + loginAttempts + "회");
+
         } catch (Exception e) {
             logger.error("로그인 실패: {}", e.getMessage());
+            // 기타 예외 처리
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("로그인 처리 중 오류가 발생했습니다.");
 
-            // 로그인 실패 시 로그인 시도 횟수 증가
-            userService.incrementLoginAttempts(loginDto.getEmail());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 실패");
         }
     }
 
@@ -143,7 +159,7 @@ public class LoginController {
         cookie.setHttpOnly(true); // 자바스크립트에서 접근 불가
         cookie.setSecure(true); // HTTPS에서만 유효하도록 설정
         cookie.setPath("/"); // 쿠키가 유효한 경로 설정
-        cookie.setMaxAge(0); // 쿠키 삭제
+        cookie.setMaxAge(0); // 쿠키 만료
         cookie.setComment("SameSite=Strict"); // CSRF 방지를 위한 SameSite 설정
 
         Cookie refreshCookie = new Cookie("refreshToken", null);

--- a/src/main/java/com/min/i/memory_BE/domain/user/service/UserService.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/service/UserService.java
@@ -176,11 +176,17 @@ public class UserService {
     // 로그인 시도 횟수를 증가시키고 계정을 잠그는 메서드
     public int incrementLoginAttempts(String email) {
         User user = userRepository.findByEmail(email).orElse(null);
-        if (user != null) {
-            user = user.toBuilder()
-                    .loginAttempts(user.getLoginAttempts() + 1)
-                    .lastLoginAttempt(LocalDateTime.now())  // 로그인 시도 시간 갱신
-                    .build();
+
+        // 이메일이 존재하지 않으면 로그인 실패 처리를 하고, 새로운 사용자 추가는 하지 않음
+        if (user == null) {
+            return 0;  // 이메일이 존재하지 않으면 로그인 실패 처리만 하고, 시도 횟수 증가하지 않음
+        }
+
+        // 로그인 시도 횟수 증가 및 로그인 시도 시간 갱신
+        user = user.toBuilder()
+                .loginAttempts(user.getLoginAttempts() + 1)
+                .lastLoginAttempt(LocalDateTime.now())  // 로그인 시도 시간 갱신
+                .build();
 
             // 로그인 시도 횟수가 5번 이상이면 계정 잠금
             if (user.getLoginAttempts() >= 5) {
@@ -190,8 +196,7 @@ public class UserService {
             }
 
             return user.getLoginAttempts();  // 로그인 시도 횟수 반환
-        }
-        return 0;
+
     }
 
     // 계정을 잠그는 메서드

--- a/src/main/java/com/min/i/memory_BE/global/config/SecurityConfig.java
+++ b/src/main/java/com/min/i/memory_BE/global/config/SecurityConfig.java
@@ -71,11 +71,18 @@ public class SecurityConfig {
                 ).permitAll() // 인증 없이 접근 허용
                 .anyRequest().authenticated() // 나머지 요청은 인증 필요
                 .and()
-                .logout()
-                .logoutRequestMatcher(new AntPathRequestMatcher("/oauth/logout", "GET")) // GET 요청 허용
-                .logoutSuccessUrl("/user/loginPage") // 로그아웃 성공 후 리다이렉트 URL
-                .invalidateHttpSession(true)  // 세션 무효화
-                .deleteCookies("JSESSIONID")  // 쿠키 삭제
+                    .logout()
+                    .logoutUrl("/auth/logout") // 일반 로그아웃 URL
+                    .logoutSuccessUrl("/user/loginPage") // 일반 로그아웃 성공 후 리다이렉트 URL
+                    .invalidateHttpSession(true) // 세션 무효화
+                    .deleteCookies("JSESSIONID", "jwtToken", "refreshToken") // 쿠키 삭제
+                    .permitAll()
+                .and()
+                    .logout()
+                    .logoutRequestMatcher(new AntPathRequestMatcher("/oauth/logout", "GET")) // GET 요청 허용
+                    .logoutSuccessUrl("/user/loginPage") // 로그아웃 성공 후 리다이렉트 URL
+                    .invalidateHttpSession(true)  // 세션 무효화
+                    .deleteCookies("JSESSIONID")  // 쿠키 삭제
                 .and()
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
                 .headers()


### PR DESCRIPTION
- 로그인 실패 시 이메일이 존재하지 않으면 새로운 사용자 삽입을 방지하고, "없는 이메일" 메시지를 반환하도록 수정
- 비밀번호가 틀린 경우 로그인 시도 횟수를 증가시키고, 로그인 실패 횟수를 클라이언트에게 반환하도록 수정
- 계정 잠금 처리 로직 개선: 로그인 시도 횟수가 5회 이상이면 계정을 잠금
- `Unique constraint violation` 오류를 방지하기 위해 이메일 존재 여부를 체크하고 새 사용자 추가를 방지하는 로직 수정