### PR TITLE
feat: 비활성화된 사용자의 로그인 처리 개선

### DIFF
--- a/src/main/java/com/min/i/memory_BE/domain/user/security/CustomUserDetails.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/security/CustomUserDetails.java
@@ -50,7 +50,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return user.getStatus() == UserStatus.ACTIVE;
+        return true;
     }
 
     // User 엔티티의 추가 정보에 접근하기 위한 메서드들

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,6 @@ spring:
       hibernate:
         default_batch_fetch_size: 100
         format_sql: true
-    hibernate:
       ddl-auto: create
     open-in-view: false
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,7 +2,7 @@
 INSERT INTO users (id, email, name, profile_img_url, password, email_verified, account_locked, login_attempts, status, created_at, updated_at)
 VALUES
 -- 시니어 케어 중심 가족
-(1, 'father1@test.com', '김아버지', 'https://min-i-album-storage.s3.ap-northeast-2.amazonaws.com/ping.png', '$2b$10$JOjRM/aFFVYmwTPcd2qNNuB13QNoC3Bbnp1vhOLRlauGme3DlkC0u', TRUE, FALSE, 0, 'ACTIVE', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()),
+(1, 'yj753110@naver.com', '김아버지', 'https://min-i-album-storage.s3.ap-northeast-2.amazonaws.com/ping.png', '$2b$10$JOjRM/aFFVYmwTPcd2qNNuB13QNoC3Bbnp1vhOLRlauGme3DlkC0u', TRUE, FALSE, 0, 'ACTIVE', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()),
 (2, 'mother1@test.com', '이어머니', 'https://min-i-album-storage.s3.ap-northeast-2.amazonaws.com/test.png', '$2b$10$JOjRM/aFFVYmwTPcd2qNNuB13QNoC3Bbnp1vhOLRlauGme3DlkC0u', TRUE, FALSE, 0, 'ACTIVE', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()),
 (3, 'grandfather1@test.com', '김할아버지', 'https://min-i-album-storage.s3.ap-northeast-2.amazonaws.com/ping.png', '$2b$10$JOjRM/aFFVYmwTPcd2qNNuB13QNoC3Bbnp1vhOLRlauGme3DlkC0u', TRUE, FALSE, 0, 'ACTIVE', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()),
 (4, 'grandmother1@test.com', '박할머니', 'https://min-i-album-storage.s3.ap-northeast-2.amazonaws.com/test.png', '$2b$10$JOjRM/aFFVYmwTPcd2qNNuB13QNoC3Bbnp1vhOLRlauGme3DlkC0u', TRUE, FALSE, 0, 'ACTIVE', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()),


### PR DESCRIPTION
- CustomUserDetails의 isEnabled() 항상 true 반환하도록 수정
  - 비활성화된 사용자도 로그인 가능하도록 변경
  - 계정 활성화를 위한 로그인 허용

- 로그인 응답에 계정 상태 확인 로직 추가
  - 비활성화된 계정 로그인 시 warning 상태와 함께 안내 메시지 반환
  - 사용자 상태 정보 포함하여 응답

- 테스트 데이터 이메일 주소 업데이트