### PR TITLE
feat: 자동 로그인 기능 구현

### DIFF
--- a/src/main/java/com/min/i/memory_BE/domain/user/controller/LoginController.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/controller/LoginController.java
@@ -49,11 +49,24 @@ public class LoginController {
     @Autowired
     private UserService userService;
 
-    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
+    @Operation(
+        summary = "로그인", 
+        description = "이메일과 비밀번호로 로그인합니다. 자동 로그인 옵션을 선택하면 리프레시 토큰의 유효기간이 30일로 설정됩니다."
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "로그인 성공"),
-            @ApiResponse(responseCode = "401", description = "로그인 실패"),
-            @ApiResponse(responseCode = "423", description = "계정이 잠김")
+        @ApiResponse(
+            responseCode = "200", 
+            description = "로그인 성공. 응답에는 사용자 정보와 함께 JWT 토큰이 쿠키로 전달됩니다. " +
+                         "자동 로그인 선택 시 리프레시 토큰은 30일, 미선택 시 7일간 유효합니다."
+        ),
+        @ApiResponse(
+            responseCode = "401", 
+            description = "로그인 실패 (잘못된 이메일 또는 비밀번호)"
+        ),
+        @ApiResponse(
+            responseCode = "423", 
+            description = "계정이 잠김 (5회 이상 로그인 실패)"
+        )
     })
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody UserLoginDto loginDto) {
@@ -104,6 +117,17 @@ public class LoginController {
                 .maxAge(60 * 60 * 24 * 7) // 7일
                 .sameSite("Strict")
                 .build();
+
+            // 자동 로그인 설정
+            if (loginDto.isRememberMe()) {
+                refreshTokenCookie = ResponseCookie.from("refreshToken", tokens.getRefreshToken())
+                    .httpOnly(true)
+                    .secure(true)
+                    .path("/")
+                    .maxAge(60 * 60 * 24 * 30) // 30일
+                    .sameSite("Strict")
+                    .build();
+            }
 
             // 사용자 상태 확인
             if (userDetails.getStatus() == UserStatus.INACTIVE) {
@@ -229,13 +253,12 @@ public class LoginController {
                         "message", "새로운 액세스 토큰이 발급되었습니다.",
                         "status", "success"
                     ));
-            } else {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(Map.of(
-                        "message", "리프레시 토큰이 유효하지 않습니다.",
-                        "status", "error"
-                    ));
             }
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(Map.of(
+                    "message", "리프레시 토큰이 유효하지 않습니다.",
+                    "status", "error"
+                ));
         } catch (Exception e) {
             logger.error("리프레시 토큰 처리 중 오류 발생: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/min/i/memory_BE/domain/user/dto/UserLoginDto.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/dto/UserLoginDto.java
@@ -7,4 +7,5 @@ public class UserLoginDto {
 
     private String email;
     private String password;
+    private boolean rememberMe; //자동 로그인 여부
 }

--- a/src/main/java/com/min/i/memory_BE/domain/user/service/EmailService.java
+++ b/src/main/java/com/min/i/memory_BE/domain/user/service/EmailService.java
@@ -244,7 +244,7 @@ public class EmailService {
             helper.setTo(email);
             helper.setSubject("Min:i 비밀번호 재설정");
             
-            String content = getPasswordResetTemplate(resetCode, jwt);  // JWT도 함께 전달
+            String content = getPasswordResetTemplate(resetCode);
             helper.setText(content, true);
             
             getMailSender(email).send(message);
@@ -256,7 +256,7 @@ public class EmailService {
         }
     }
 
-    private String getPasswordResetTemplate(String resetCode, String jwt) {
+    private String getPasswordResetTemplate(String resetCode) {
         return "<div style='max-width: 600px; margin: 20px auto; padding: 20px;'>"
             + "<h2>Min:i 비밀번호 재설정</h2>"
             + "<p>비밀번호 재설정을 위한 인증 코드입니다:</p>"


### PR DESCRIPTION
- 로그인 DTO에 자동 로그인 옵션 추가
  - UserLoginDto에 rememberMe 필드 추가

- 자동 로그인 시 리프레시 토큰 유효기간 연장
  - 일반 로그인: 7일
  - 자동 로그인: 30일

- API 문서 개선
  - 로그인 API 설명에 자동 로그인 관련 내용 추가
  - 응답 상태 코드별 상세 설명 추가